### PR TITLE
Mark application as end-of-life (EOL)

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application is no longer maintained"
+}


### PR DESCRIPTION
`OpenDrive` hasn't had any updates since 2019. It doesn't work, and the owner/maintainer is not responsive. I tried to contact him/her several times through different means, but no response so far.